### PR TITLE
Fix TypeScript warnings by installing node type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "build:watch": "tsc -p ./tsconfig.json -d -w"
     },
     "devDependencies": {
+        "@types/node": "^10.12.17",
         "gatsby": "^2.0.52",
         "tsc": "^1.20150623.0",
         "typescript": "^3.1.6"


### PR DESCRIPTION
The warnings we're currently getting can be fixed by giving TypeScript some type definitions for the core Node libraries, which someone else has helpfully written for us, and TypeScript will helpfully consume by simply installing the npm package.